### PR TITLE
Final SR cutflow + fixing stop x-section

### DIFF
--- a/RootTools/python/samples/samples_13TeV_76X_susySignalsPriv.py
+++ b/RootTools/python/samples/samples_13TeV_76X_susySignalsPriv.py
@@ -42,7 +42,7 @@ T2tt = []
 ## T2ttDeg
 ## ------------------------------------------------------
 #T2ttDeg_mStop350_mChi330_4bodydec = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec', '/T2ttDeg_mStop350_mChi330_4bodydec/', '/store/cmst3/group/susy/gpetrucc/13TeV/RunIISpring15DR74/%s',".*root", 0.003787)
-T2ttDeg_mStop350_mChi330_4bodydec_lepOnly = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec_lepOnly', '/T2ttDeg_miniAODSIM_76X_lepOnly_dM20gev/','/store/user/castello/susy/%s',".*root", 3.786*(0.332)*(0.332))
+T2ttDeg_mStop350_mChi330_4bodydec_lepOnly = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec_lepOnly', '/T2ttDeg_miniAODSIM_76X_lepOnly_dM20gev/','/store/user/castello/susy/%s',".*root", 3.787*(0.332)*(0.332))
 T2ttDeg = [ T2ttDeg_mStop350_mChi330_4bodydec_lepOnly ]
 
 

--- a/RootTools/python/samples/samples_13TeV_76X_susySignalsPriv.py
+++ b/RootTools/python/samples/samples_13TeV_76X_susySignalsPriv.py
@@ -42,7 +42,7 @@ T2tt = []
 ## T2ttDeg
 ## ------------------------------------------------------
 #T2ttDeg_mStop350_mChi330_4bodydec = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec', '/T2ttDeg_mStop350_mChi330_4bodydec/', '/store/cmst3/group/susy/gpetrucc/13TeV/RunIISpring15DR74/%s',".*root", 0.003787)
-T2ttDeg_mStop350_mChi330_4bodydec_lepOnly = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec_lepOnly', '/T2ttDeg_miniAODSIM_76X_lepOnly_dM20gev/','/store/user/castello/susy/%s',".*root", 0.003787*(0.332)*(0.332))
+T2ttDeg_mStop350_mChi330_4bodydec_lepOnly = kreator.makeMCComponentFromEOS('T2ttDeg_mStop350_mChi330_4bodydec_lepOnly', '/T2ttDeg_miniAODSIM_76X_lepOnly_dM20gev/','/store/user/castello/susy/%s',".*root", 3.786*(0.332)*(0.332))
 T2ttDeg = [ T2ttDeg_mStop350_mChi330_4bodydec_lepOnly ]
 
 

--- a/TTHAnalysis/python/plotter/susy-sos/susy_2los_ichep16_SR.txt
+++ b/TTHAnalysis/python/plotter/susy-sos/susy_2los_ichep16_SR.txt
@@ -1,15 +1,15 @@
 ### Dilepton final state ####################
 nLep: nLepGood == 2
 OS-ll: LepGood1_pdgId*LepGood2_pdgId<0
-OS-ll (ee,mm) : LepGood1_pdgId*LepGood2_pdgId==-169||LepGood1_pdgId*LepGood2_pdgId==-121
+#OS-ll (ee,mm) : LepGood1_pdgId*LepGood2_pdgId==-169 || LepGood1_pdgId*LepGood2_pdgId==-121
 
 ### To match old trigger requirements (for both ee and mumu) ######
 pTj1eta:fabs(Jet1_eta)<2.4 
 pTj1pt: Jet1_pt > 25
-jetMET: met_pt > 200 
+#jetMET: met_pt > 200 
 
 ### When new trigger will be in the menu ##
-##jetMET: (LepGood1_pdgId*LepGood2_pdgId==-121 && met_pt > 200) || (LepGood1_pdgId*LepGood2_pdgId==-169 && met_pt>100) 
+jetMET: met_pt > 200 || (LepGood1_pdgId*LepGood2_pdgId==-169 && met_pt>100) 
 
 ### Lepton acceptance ###############################
 ledlepPt: 5 < LepGood1_pt && LepGood1_pt < 20
@@ -19,9 +19,10 @@ eta: ((fabs(LepGood1_pdgId)==13 && fabs(LepGood1_eta) < 2.4) || (fabs(LepGood1_p
 lepIP:fabs(LepGood1_dxy)<0.01 && fabs(LepGood1_dz)<0.01 && fabs(LepGood2_dxy)<0.01 && fabs(LepGood2_dz)<0.01 
 
 ### lepton ID/ISO #########################
+
 lepID: ((fabs(LepGood1_pdgId)==13) || (fabs(LepGood1_pdgId)==11 && ((LepGood1_pt<=10.0 && ((fabs(LepGood1_etaSc)<0.8 && LepGood1_mvaIdSpring15>-0.265) || (fabs(LepGood1_etaSc)>=0.8 && fabs(LepGood1_etaSc)<1.479&&LepGood1_mvaIdSpring15>-0.556)||(fabs(LepGood1_etaSc)>=1.479 && LepGood1_mvaIdSpring15 > -0.551))) || (LepGood1_pt>10.0 && ((fabs(LepGood1_etaSc)<0.8 && LepGood1_mvaIdSpring15>-0.072)||(fabs(LepGood1_etaSc)>=0.8 && fabs(LepGood1_etaSc)<1.479 && LepGood1_mvaIdSpring15>-0.286)||(fabs(LepGood1_etaSc)>=1.479 && LepGood1_mvaIdSpring15 >-0.267)))))) &&  ((fabs(LepGood2_pdgId)==13) || (fabs(LepGood2_pdgId)==11 && ((LepGood2_pt<=10.0 && ((fabs(LepGood2_etaSc)<0.8 && LepGood2_mvaIdSpring15>-0.265) || (fabs(LepGood2_etaSc)>=0.8 && fabs(LepGood2_etaSc)<1.479&&LepGood2_mvaIdSpring15>-0.556)||(fabs(LepGood2_etaSc)>=1.479 && LepGood2_mvaIdSpring15 > -0.551))) || (LepGood2_pt>10.0 && ((fabs(LepGood2_etaSc)<0.8 && LepGood2_mvaIdSpring15>-0.072)||(fabs(LepGood2_etaSc)>=0.8 && fabs(LepGood2_etaSc)<1.479 && LepGood2_mvaIdSpring15>-0.286)||(fabs(LepGood2_etaSc)>=1.479 && LepGood2_mvaIdSpring15 >-0.267))))))
 lepISO:LepGood1_relIso03<0.5 && (LepGood1_relIso03*LepGood1_pt)<5. && LepGood2_relIso03<0.5 && (LepGood2_relIso03*LepGood2_pt)<5.
-
+eleConvVeto: (LepGood1_pdgId*LepGood2_pdgId==-169) || (LepGood1_pdgId*LepGood2_pdgId==-121 && LepGood1_lostHits==0 && LepGood2_lostHits==0 && LepGood1_convVeto==1 && LepGood2_convVeto==1)
 
 #### Against QCD ##########################
 MET/HT : (met_pt/(htJet25-LepGood1_pt-LepGood2_pt))>(2/3)


### PR DESCRIPTION
- Defining reference cutflow for the SR as discussed. Including also the e-mu category (for accomodating stop searches) and the convVeto==1 and lostHits==0 for electrons (which was missing).

- Fixing the value of stop x-section according to SUSY cross section WG 