### PR TITLE
RuntimeError when overwriting extra options upon including mca files

### DIFF
--- a/TTHAnalysis/python/plotter/mcAnalysis.py
+++ b/TTHAnalysis/python/plotter/mcAnalysis.py
@@ -65,7 +65,8 @@ class MCAnalysis:
                         extra[key] = eval(val)
                     else: extra[setting] = True
             for k,v in addExtras.iteritems():
-                if k in extra: raise RuntimeError, 'You are trying to overwrite an extra option already set'
+                if k in extra and extra[k] != v:
+                    raise RuntimeError('You are trying to overwrite an extra option: %s'%k)
                 extra[k] = v
             field = [f.strip() for f in line.split(':')]
             if len(field) == 1 and field[0] == "*":


### PR DESCRIPTION
Seems unnecessary to raise a RuntimeError here, unless the overwritten option is actually different.
It could even be just a warning, but maybe I'm missing something?