### PR TITLE
new datacard maker based on uncertainty file

### DIFF
--- a/TTHAnalysis/python/plotter/histoWithNuisances.py
+++ b/TTHAnalysis/python/plotter/histoWithNuisances.py
@@ -8,6 +8,21 @@ def _cloneNoDir(hist,name=''):
     ret.SetDirectory(None)
     return ret
 
+def cropNegativeBins(histo):
+            if "TH1" in histo.ClassName():
+                for b in xrange(0,histo.GetNbinsX()+2):
+                    if histo.GetBinContent(b) < 0: histo.SetBinContent(b, 0.0)
+            elif "TH2" in histo.ClassName():
+                for bx in xrange(0,histo.GetNbinsX()+2):
+                    for by in xrange(0,histo.GetNbinsY()+2):
+                        if histo.GetBinContent(bx,by) < 0: histo.SetBinContent(bx,by, 0.0)
+            elif "TH3" in histo.ClassName():
+                for bx in xrange(0,histo.GetNbinsX()+2):
+                    for by in xrange(0,histo.GetNbinsY()+2):
+                        for bz in xrange(0,histo.GetNbinsZ()+2):
+                            if histo.GetBinContent(bx,by,bz) < 0: histo.SetBinContent(bx,by,bz, 0.0)
+
+
 class RooFitContext:
     def __init__(self,workspace):
         self.workspace = workspace
@@ -334,7 +349,12 @@ class HistoWithNuisances:
             ret.SetPoint(i, x, y)
             ret.SetPointError(i, EXlow,EXhigh,EYlow,EYhigh)
         return ret
-
+    def cropNegativeBins(self, allVariations=True):
+        cropNegativeBins(self.nominal)
+        if allVariations:
+            cropNegativeBins(self.central)
+            for hs in self.variations.itervalues():
+                for h in hs: cropNegativeBins(h)
     def getCentral(self):
         return self.central
     def getVariation(self,alternate):

--- a/TTHAnalysis/python/plotter/makeShapeCards.py
+++ b/TTHAnalysis/python/plotter/makeShapeCards.py
@@ -49,8 +49,8 @@ def file2map(x):
             fields = [ float(i) for i in cols ]
             ret[fields[0]] = dict(zip(headers,fields[1:]))
     return ret
-#YRpath = os.environ['CMSSW_RELEASE_BASE']+"/src/HiggsAnalysis/CombinedLimit/data/lhc-hxswg/sm/";
-YRpath = '/afs/cern.ch/user/p/peruzzi/work/cmgtools/combine/CMSSW_7_4_14/src/HiggsAnalysis/CombinedLimit/data/lhc-hxswg/sm/'
+YRpath = os.environ['CMSSW_BASE']+"/src/HiggsAnalysis/CombinedLimit/data/lhc-hxswg/sm/";
+#YRpath = '/afs/cern.ch/user/p/peruzzi/work/cmgtools/combine/CMSSW_7_4_14/src/HiggsAnalysis/CombinedLimit/data/lhc-hxswg/sm/'
 #XStth = file2map(YRpath+"xs/8TeV/8TeV-ttH.txt")
 BRhvv = file2map(YRpath+"br/BR2bosons.txt")
 BRhff = file2map(YRpath+"br/BR2fermions.txt")
@@ -117,7 +117,8 @@ def rebin2Dto1D(h,funcstring):
             newh.SetBinError(bin,math.hypot(newh.GetBinError(bin),h.GetBinError(i+1,j+1)))
     for bin in range(1,nbins+1):
         if newh.GetBinContent(bin)<0:
-            print 'Warning: cropping to zero bin %d in %s (was %f)'%(bin,newh.GetName(),newh.GetBinContent(bin))
+            if "promptsub" not in str(newh.GetName()):
+                print 'Warning: cropping to zero bin %d in %s (was %f)'%(bin,newh.GetName(),newh.GetBinContent(bin))
             newh.SetBinContent(bin,0)
     newh.SetLineWidth(h.GetLineWidth())
     newh.SetLineStyle(h.GetLineStyle())
@@ -540,23 +541,27 @@ for mass in masses:
     klen = max([7, len(binname)]+[len(p) for p in procs])
     kpatt = " %%%ds "  % klen
     fpatt = " %%%d.%df " % (klen,3)
+    npatt = "%%-%ds " % (1+max([len('process')]+map(len,systs.keys())+map(len,systsEnv.keys())))
     datacard.write('##----------------------------------\n')
-    datacard.write('bin             '+(" ".join([kpatt % binname  for p in procs]))+"\n")
-    datacard.write('process         '+(" ".join([kpatt % p        for p in procs]))+"\n")
-    datacard.write('process         '+(" ".join([kpatt % iproc[p] for p in procs]))+"\n")
-    datacard.write('rate            '+(" ".join([fpatt % myyields[p] for p in procs]))+"\n")
+    datacard.write((npatt % 'bin    ')+(" "*6)+(" ".join([kpatt % binname  for p in procs]))+"\n")
+    datacard.write((npatt % 'process')+(" "*6)+(" ".join([kpatt % p        for p in procs]))+"\n")
+    datacard.write((npatt % 'process')+(" "*6)+(" ".join([kpatt % iproc[p] for p in procs]))+"\n")
+    datacard.write((npatt % 'rate   ')+(" "*6)+(" ".join([fpatt % myyields[p] for p in procs]))+"\n")
     datacard.write('##----------------------------------\n')
-    for name,effmap in systs.iteritems():
-        datacard.write(('%-12s lnN' % name) + " ".join([kpatt % effmap[p]   for p in procs]) +"\n")
-    for name,(effmap0,effmap12,mode) in systsEnv.iteritems():
+    for name in sorted(systs.keys() + systsEnv.keys()):
+      if name in systs:  
+        effmap = systs[name]
+        datacard.write(('%s   lnN' % (npatt%name)) + " ".join([kpatt % effmap[p]   for p in procs]) +"\n")
+      else:
+        (effmap0,effmap12,mode) = systsEnv[name]
         if re.match('templates.*',mode):
-            datacard.write(('%-10s shape' % name) + " ".join([kpatt % effmap0[p]  for p in procs]) +"\n")
+            datacard.write(('%s shape' % (npatt%name)) + " ".join([kpatt % effmap0[p]  for p in procs]) +"\n")
         if re.match('envelop.*',mode):
-            datacard.write(('%-10s shape' % (name+"0")) + " ".join([kpatt % effmap0[p]  for p in procs]) +"\n")
+            datacard.write(('%s shape' % (npatt%(name+"0"))) + " ".join([kpatt % effmap0[p]  for p in procs]) +"\n")
         if any([re.match(x+'.*',mode) for x in ["envelop", "shapeOnly"]]):
-            datacard.write(('%-10s shape' % (name+"1")) + " ".join([kpatt % effmap12[p] for p in procs]) +"\n")
+            datacard.write(('% shape' % (npatt%(name+"1"))) + " ".join([kpatt % effmap12[p] for p in procs]) +"\n")
             if "shapeOnly2D" not in mode:
-                datacard.write(('%-10s shape' % (name+"2")) + " ".join([kpatt % effmap12[p] for p in procs]) +"\n")
+                datacard.write(('%-10s shape' % (npatt%(name+"2"))) + " ".join([kpatt % effmap12[p] for p in procs]) +"\n")
 if len(masses) > 1:
     myout = outdir
     myyields = dict([(k,-1 if "ttH" in k else v) for (k,v) in allyields.iteritems()]) 

--- a/TTHAnalysis/python/plotter/makeShapeCardsNew.py
+++ b/TTHAnalysis/python/plotter/makeShapeCardsNew.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+from CMGTools.TTHAnalysis.plotter.mcAnalysis import *
+import re, sys, os, os.path
+systs = {}
+
+from optparse import OptionParser
+parser = OptionParser(usage="%prog [options] mc.txt cuts.txt var bins")
+addMCAnalysisOptions(parser)
+parser.add_option("--od", "--outdir", dest="outdir", type="string", default=None, help="output directory name") 
+parser.add_option("--asimov", dest="asimov", type="string", default=None, help="Use an Asimov dataset of the specified kind: including signal ('signal','s','sig','s+b') or background-only ('background','bkg','b','b-only')")
+parser.add_option("--bbb", dest="bbb", type="string", default='standard', help="Options for bin-by-bin statistical uncertainties with the specified nuisance name")
+parser.add_option("--infile", dest="infile", action="store_true", default=False, help="Read histograms to file")
+parser.add_option("--savefile", dest="savefile", action="store_true", default=False, help="Save histos to file")
+
+(options, args) = parser.parse_args()
+options.weight = True
+options.final  = True
+
+if "/functions_cc.so" not in ROOT.gSystem.GetLibraries(): 
+    ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/TTHAnalysis/python/plotter/functions.cc+" % os.environ['CMSSW_BASE']);
+
+mca  = MCAnalysis(args[0],options)
+cuts = CutsFile(args[1],options)
+
+truebinname = os.path.basename(args[1]).replace(".txt","") if options.binname == None else options.binname
+binname = truebinname if truebinname[0] not in "234" else "ttH_"+truebinname
+print binname
+outdir  = options.outdir+"/" if options.outdir else ""
+if not os.path.exists(outdir): os.mkdir(outdir)
+
+report={}
+if options.infile:
+    infile = ROOT.TFile(outdir+binname+".bare.root","read")
+    for p in mca.listSignals(True)+mca.listBackgrounds(True)+['data']:
+        variations = mca.getProcessNuisances(p) if p != "data" else []
+        h = readHistoWithNuisances(infile, "x_"+p, variations, mayBeMissing=True)
+        if h: report[p] = h
+else:
+    report = mca.getPlotsRaw("x", args[2], args[3], cuts.allCuts(), nodata=options.asimov) 
+    for p,h in report.iteritems(): h.cropNegativeBins()
+
+if options.bbb:
+    for p,h in report.iteritems(): 
+        h.addBinByBin(namePattern="%s_%s_%s_bin{bin}" % (options.bbb, truebinname, p), conservativePruning = True)
+
+if options.savefile:
+    savefile = ROOT.TFile(outdir+binname+".bare.root","recreate")
+    for k,h in report.iteritems(): 
+        h.writeToFile(savefile, takeOwnership=False)
+    savefile.Close()
+
+nuisances = sorted(listAllNuisances(report))
+
+if options.asimov:
+    if options.asimov in ("s","sig","signal","s+b"):
+        asimovprocesses = mca.listSignals() + mca.listBackgrounds()
+    elif options.asimov in ("b","bkg","background", "b-only"):
+        asimovprocesses = mca.listBackgrounds()
+    else: raise RuntimeError("the --asimov option requires to specify signal/sig/s/s+b or background/bkg/b/b-only")
+    tomerge = None
+    for p in asimovprocesses:
+        if p in report: 
+            if tomerge is None: tomerge = report[p].raw().Clone("x_data_obs")
+            else: tomerge.Add(report[p].raw())
+    report['data_obs'] = tomerge 
+else:
+    report['data_obs'] = report['data'].raw().Clone("x_data_obs") 
+
+
+allyields = dict([(p,h.Integral()) for p,h in report.iteritems()])
+procs = []; iproc = {}
+for i,s in enumerate(mca.listSignals()):
+    if s not in allyields: continue
+    if allyields[s] == 0: continue
+    procs.append(s); iproc[s] = i-len(mca.listSignals())+1
+for i,b in enumerate(mca.listBackgrounds()):
+    if b not in allyields: continue
+    if allyields[b] == 0: continue
+    procs.append(b); iproc[b] = i+1
+for p in procs: print "%-10s %10.4f" % (p, allyields[p])
+
+systs = {}
+for name in nuisances:
+    effshape = {}
+    isShape = False
+    for p in procs:
+        h = report[p]
+        if h.hasVariation(name):
+            if isShape or h.isShapeVariation(name):
+                #print "Nuisance %s has a shape effect on process %s" % (name, p)
+                isShape = True
+            effshape[p] = h.getVariation(name)
+    if isShape:
+        systs[name] = ("shape", dict((p,"1" if p in effshape else "-") for p in procs), effshape)
+    else:
+        effyield = dict((p,"-") for p in procs)
+        isNorm = False
+        for p,(hup,hdn) in effshape.iteritems():
+            i0 = allyields[p]
+            kup, kdn = hup.Integral()/i0, hdn.Integral()/i0
+            if abs(kup*kdn-1)<1e-5:
+                if abs(kup-1)>2e-4:
+                    effyield[p] = "%.3f" % kup
+                    isNorm = True
+            else:
+                effyield[p] = "%.3f/%.3f" % (kdn,kup)
+                isNorm = True
+        if isNorm:
+            systs[name] = ("lnN", effyield, {})
+# make a new list with only the ones that have an effect
+nuisances = sorted(systs.keys())
+
+
+datacard = open(outdir+binname+".card.txt", "w"); 
+datacard.write("## Datacard for cut file %s\n"%args[1])
+datacard.write("shapes *        * %s.input.root x_$PROCESS x_$PROCESS_$SYSTEMATIC\n" % binname)
+datacard.write('##----------------------------------\n')
+datacard.write('bin         %s\n' % binname)
+datacard.write('observation %s\n' % allyields['data_obs'])
+datacard.write('##----------------------------------\n')
+klen = max([7, len(binname)]+[len(p) for p in procs])
+kpatt = " %%%ds "  % klen
+fpatt = " %%%d.%df " % (klen,3)
+npatt = "%%-%ds " % max([len('process')]+map(len,nuisances))
+datacard.write('##----------------------------------\n')
+datacard.write((npatt % 'bin    ')+(" "*6)+(" ".join([kpatt % binname  for p in procs]))+"\n")
+datacard.write((npatt % 'process')+(" "*6)+(" ".join([kpatt % p        for p in procs]))+"\n")
+datacard.write((npatt % 'process')+(" "*6)+(" ".join([kpatt % iproc[p] for p in procs]))+"\n")
+datacard.write((npatt % 'rate   ')+(" "*6)+(" ".join([fpatt % allyields[p] for p in procs]))+"\n")
+datacard.write('##----------------------------------\n')
+towrite = [ report[p].raw() for p in procs ] + [ report["data_obs"] ]
+for name in nuisances:
+    (kind,effmap,effshape) = systs[name]
+    datacard.write(('%s %5s' % (npatt % name,kind)) + " ".join([kpatt % effmap[p]  for p in procs]) +"\n")
+    for p,(hup,hdn) in effshape.iteritems():
+        towrite.append(hup.Clone("x_%s_%sUp"   % (p,name)))
+        towrite.append(hdn.Clone("x_%s_%sDown" % (p,name)))
+
+workspace = ROOT.TFile.Open(outdir+binname+".input.root", "RECREATE")
+for h in towrite:
+    workspace.WriteTObject(h,h.GetName())
+workspace.Close()
+
+print "Wrote to ",outdir+binname+".input.root"
+

--- a/TTHAnalysis/python/plotter/mcAnalysis.py
+++ b/TTHAnalysis/python/plotter/mcAnalysis.py
@@ -150,9 +150,9 @@ class MCAnalysis:
             if self.variationsFile:
                 for var in self.variationsFile.uncertainty():
                     if var.procmatch().match(pname) and var.binmatch().match(options.binname): 
-                        if var.name in variations:
-                            print "Variation %s overriden for process %s, new process pattern %r, bin %r (old had %r, %r)" % (
-                                    var.name, pname, var.procpattern(), var.binpattern(), variations[var.name].procpattern(), variations[var.name].binpattern())
+                        #if var.name in variations:
+                        #    print "Variation %s overriden for process %s, new process pattern %r, bin %r (old had %r, %r)" % (
+                        #            var.name, pname, var.procpattern(), var.binpattern(), variations[var.name].procpattern(), variations[var.name].binpattern())
                         variations[var.name] = var
                 if 'NormSystematic' in extra:
                     del extra['NormSystematic']
@@ -313,6 +313,11 @@ class MCAnalysis:
         elif process in self._optionsOnlyProcesses:
             self._optionsOnlyProcesses[process][name] = value
         else: raise RuntimeError, "Can't set option %s for undefined process %s" % (name,process)
+    def getProcessNuisances(self,process):
+        ret = set()
+        for tty in self._allData[process]: 
+            ret.update([v.name for v in tty.getVariations()])
+        return ret
     def getScales(self,process):
         return [ tty.getScaleFactor() for tty in self._allData[process] ] 
     def setScales(self,process,scales):
@@ -672,7 +677,7 @@ class MCAnalysis:
             if k2 not in mergemap: mergemap[k2]=[]
             mergemap[k2].append(v)
         for k3 in mergemap:
-            mergemap[k3].sort(lambda x: x!=k3)
+            mergemap[k3].sort(key=lambda x: x!=k3)
         return dict([ (k,mergePlots(pspec.name+"_"+k,v)) for k,v in mergemap.iteritems() ])
     def stylePlot(self,process,plot,pspec,mayBeMissing=False):
         if process in self._allData:

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -19,7 +19,7 @@ from CMGTools.TTHAnalysis.plotter.cutsFile import *
 from CMGTools.TTHAnalysis.plotter.mcCorrections import *
 from CMGTools.TTHAnalysis.plotter.fakeRate import *
 from CMGTools.TTHAnalysis.plotter.uncertaintyFile import *
-from CMGTools.TTHAnalysis.plotter.histoWithNuisances import HistoWithNuisances
+from CMGTools.TTHAnalysis.plotter.histoWithNuisances import HistoWithNuisances, cropNegativeBins
 
 if "/functions_cc.so" not in ROOT.gSystem.GetLibraries(): 
     ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/TTHAnalysis/python/plotter/functions.cc+" % os.environ['CMSSW_BASE']);
@@ -118,20 +118,6 @@ def makeHistFromBinsAndSpec(name,expr,bins,plotspec):
             raise RuntimeError, "Can't make a plot with %d dimensions" % nvars
         histo.Sumw2()
         return histo
-
-def cropNegativeBins(histo):
-            if "TH1" in histo.ClassName():
-                for b in xrange(0,histo.GetNbinsX()+2):
-                    if histo.GetBinContent(b) < 0: histo.SetBinContent(b, 0.0)
-            elif "TH2" in histo.ClassName():
-                for bx in xrange(0,histo.GetNbinsX()+2):
-                    for by in xrange(0,histo.GetNbinsY()+2):
-                        if histo.GetBinContent(bx,by) < 0: histo.SetBinContent(bx,by, 0.0)
-            elif "TH3" in histo.ClassName():
-                for bx in xrange(0,histo.GetNbinsX()+2):
-                    for by in xrange(0,histo.GetNbinsY()+2):
-                        for bz in xrange(0,histo.GetNbinsZ()+2):
-                            if histo.GetBinContent(bx,by,bz) < 0: histo.SetBinContent(bx,by,bz, 0.0)
 
 
 class TreeToYield:

--- a/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_MC.sh
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_MC.sh
@@ -111,10 +111,12 @@ for WP in $WPs; do
 	    sMi*)    ptJI="ptJIMIX4";;
 	esac
         B0="$BASE -P $T ttH-multilepton/make_fake_rates_sels.txt ttH-multilepton/make_fake_rates_xvars.txt --groupBy cut --sP ${Num} " 
+        B0="$B0 --Fs {P}/1_jetPtRatiov3_v1 --mcc ttH-multilepton/mcc-ptRatiov3.txt "
         B0="$B0 --mcc ttH-multilepton/mcc-eleIdEmu2.txt  "
         #B0="$B0 --legend=TR --showRatio --ratioRange 0.41 1.59   --yrange 0 0.20 " 
         B0="$B0 --legend=TR --showRatio --ratioRange 0.00 1.99   --yrange 0 0.25 " 
 	B1="${PLOTTER} -P $T ttH-multilepton/make_fake_rates_plots.txt"
+        B1="$B1 --Fs {P}/1_jetPtRatiov3_v1 --mcc ttH-multilepton/mcc-ptRatiov3.txt "
 	B1="${B1} --mcc ttH-multilepton/mcc-eleIdEmu2.txt  "
         B1="$B1 --showRatio --maxRatioRange 0 2 --plotmode=norm -f "
         JetDen="-A pt20 mll 'nLepGood == 1'"

--- a/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_MC.sh
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_MC.sh
@@ -102,7 +102,8 @@ for WP in $WPs; do
 	    *ptJ90*)    ptJI="ptJI90";;
 	    *ptJ95*)    ptJI="ptJI95";;
 	    090*)    ptJI="ptJI90";;
-	    075*)    ptJI="ptJI80";;
+	    075*)    ptJI="ptJI90";;
+	    #075*)    ptJI="ptJI80";;
 	    RA*)  ptJI="conePt";;
 	    sViX0*)    ptJI="ptJI85";;
 	    sMiX0*)    ptJI="ptJI85";;

--- a/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_data.sh
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_data.sh
@@ -18,7 +18,7 @@ susy*) echo "NOT UP TO DATE"; exit 1;;
 *) echo "You did not specify the analysis"; exit 1;;
 esac;
 BCORE=" --s2v --tree treeProducerSusyMultilepton ttH-multilepton/mca-qcd1l.txt ${CUTFILE} -P $T -l 41.7 --AP  --WA prescaleFromSkim  "
-#BCORE="${BCORE} --Fs {P}/1_extraVars_v1  "
+BCORE="${BCORE} --Fs {P}/1_jetPtRatiov3_v1 --mcc ttH-multilepton/mcc-ptRatiov3.txt "
 BCORE="${BCORE} --mcc ttH-multilepton/mcc-eleIdEmu2.txt  "; 
 #BCORE="${BCORE} --mcc ttH-multilepton/mcc-noHLTinMC-some.txt  "; 
 

--- a/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_data.sh
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_data.sh
@@ -22,12 +22,21 @@ BCORE=" --s2v --tree treeProducerSusyMultilepton ttH-multilepton/mca-qcd1l.txt $
 BCORE="${BCORE} --mcc ttH-multilepton/mcc-eleIdEmu2.txt  "; 
 #BCORE="${BCORE} --mcc ttH-multilepton/mcc-noHLTinMC-some.txt  "; 
 
+MVAWP=90
+
 BG=" -j 8 "; if [[ "$1" == "-b" ]]; then BG=" & "; shift; fi
 
 lepton=$1; if [[ "$1" == "" ]]; then exit 1; fi
+lepdir=${lepton};
 case $lepton in
 mu) BCORE="${BCORE} -E ^${lepton} --xf 'SingleEl.*'  "; QCD=QCDMu; ;;
 el) BCORE="${BCORE} -E ^${lepton} --xf 'DoubleMu.*,SingleMu.*' "; QCD=QCDEl; ;;
+loose_mu) 
+    lepdir=$1; lepton="mu"; MVAWP=75; CUTPREFIX="mva0${MVAWP}_"; NUM="mvaPt_0${MVAWP}i";
+    BCORE="${BCORE} -E ^${lepton} --xf 'SingleEl.*'  "; QCD=QCDMu; ;;
+loose_el) 
+    lepdir=$1; lepton="el"; MVAWP=75; CUTPREFIX="mva0${MVAWP}_"; NUM="mvaPt_0${MVAWP}i";
+    BCORE="${BCORE} -E ^${lepton} --xf 'DoubleMu.*,SingleMu.*' "; QCD=QCDEl; ;;
 #mu_jet) lepton="mu"; BCORE="${BCORE} -E ${lepton} --xf 'Double.*' -X idEmuCut -R minimal ptj40 ' LepGood_awayJet_pt > 40'  "; QCD=QCDMu; ;;
 #mu_jet6) lepton="mu"; BCORE="${BCORE} -E ${lepton} --xf 'Double.*,JetHT_.*' -X idEmuCut -R minimal ptj40 ' LepGood_awayJet_pt > 60'  "; QCD=QCDMu; ;;
 #mu_ht)  lepton="mu"; BCORE="${BCORE} -E ${lepton} --xf 'Double.*' -X idEmuCut -R minimal ptj40 ' LepGood_awayJet_pt > 40'  "; QCD=QCDMu; ;;
@@ -35,7 +44,7 @@ el) BCORE="${BCORE} -E ^${lepton} --xf 'DoubleMu.*,SingleMu.*' "; QCD=QCDEl; ;;
 esac;
 
 trigger=$2; if [[ "$2" == "" ]]; then exit 1; fi
-conept="LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2)"
+conept="LepGood_pt*if3(LepGood_mvaTTH>0.${MVAWP}&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2)"
 case $trigger in
 #PFJet6)
 #    BCORE="${BCORE} -E HLT_PFJet6   "; 
@@ -70,8 +79,8 @@ MuX_Combined)
     PUW=" "
     ;;
 MuX_OR)
-    BCORE="${BCORE} -E trigMu -E conePt10 -E notConePt100 "; 
-    CONEPTVAR="ptJI90_mvaPt090_coarsecomb"
+    BCORE="${BCORE} -E ^${CUTPREFIX}trigMu -E ^${CUTPREFIX}conePt10 -E ^${CUTPREFIX}notConePt100 "; 
+    CONEPTVAR="ptJI90_mvaPt0${MVAWP}_coarsecomb"
     PUW="-L ttH-multilepton/frPuReweight.cc -W 'coneptw$trigger($conept,nVert)' "
     ;;
 Ele8|Ele8_CaloIdM_TrackIdM_PFJet30)
@@ -91,9 +100,8 @@ EleX_Combined)
     PUW=" "
     ;;
 EleX_OR)
-    BCORE="${BCORE/TREES_TTH_120218_Fall17_JECV4_1L/TREES_TTH_120218_Fall17_JECV4_1L_exclusiveData}";
-    BCORE="${BCORE} -E trigEl -E conePt15 -E notConePt100 "; 
-    CONEPTVAR="ptJI90_mvaPt090_coarseelcomb"
+    BCORE="${BCORE} -E ^${CUTPREFIX}trigEl -E ^${CUTPREFIX}conePt15 -E ^${CUTPREFIX}notConePt100 "; 
+    CONEPTVAR="ptJI90_mvaPt0${MVAWP}_coarseelcomb"
     PUW="-L ttH-multilepton/frPuReweight.cc -W 'coneptw$trigger($conept,nVert)' "
     ;;
 *)
@@ -105,7 +113,7 @@ esac;
 
 what=$3;
 more=$4
-PBASE="plots/94X/${ANALYSIS}/lepMVA/v2.0-dev/fr-meas/qcd1l/$lepton/HLT_$trigger/$what/$more"
+PBASE="plots/94X/${ANALYSIS}/lepMVA/v2.0-dev/fr-meas/qcd1l/$lepdir/HLT_$trigger/$what/$more"
 
 EWKONE="-p ${QCD}_red,EWK,data"
 EWKSPLIT="-p ${QCD}_red,WJets,DYJets,Top,data"

--- a/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_xvars.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/make_fake_rates_xvars.txt
@@ -55,10 +55,12 @@ ptJI90_mvaPt090_coarsemu17bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_medi
 ptJI90_mvaPt090_coarsemu20bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 30,32,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarsemu27bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 40,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarsecomb:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 10,15,20,32,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
+ptJI90_mvaPt075_coarsecomb:  LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 10,15,20,32,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarseel8bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 13,15,25,35,45,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarseel17bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 25,35,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarseel23bin:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 35,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarseelcomb:  LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 15,25,35,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
+ptJI90_mvaPt075_coarseelcomb:  LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 15,25,35,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarsecomblo: LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 5,10,15,20,32,45 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_coarsecombhi: LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 20,32,45,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True
 ptJI90_mvaPt090_finecombhi: LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2): [ 20,30,45,65,100 ]; XTitle="lepton p_{T}^{corr} (GeV)", Density=True

--- a/TTHAnalysis/python/plotter/ttH-multilepton/mca-2lss-mcdata-frdata.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/mca-2lss-mcdata-frdata.txt
@@ -1,3 +1,4 @@
+# vim: syntax=sh
 incl_sigprompt : + ; IncludeMca="ttH-multilepton/mca-includes/mca-2lss-sigprompt.txt"
 incl_convs     : + ; IncludeMca="ttH-multilepton/mca-includes/mca-2lss-convs.txt"
 incl_datafakes  : + ; IncludeMca="ttH-multilepton/mca-includes/mca-data.txt", FakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", Label="Non-prompt", FillColor=ROOT.kBlack, FillStyle=3005, PostFix='_fakes'

--- a/TTHAnalysis/python/plotter/ttH-multilepton/mca-includes/mca-tt-more.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/mca-includes/mca-tt-more.txt
@@ -1,0 +1,5 @@
+TT : TTJets_DiLepton_part1+TTJets_DiLepton_part2 : xsec*0.27
+TT : TTLep_pow_part1+TTLep_pow_part2+TTLep_pow_part3+TTLep_pow_part4+TTLep_pow_part5 : xsec*0.73
+TT : TTJets_SingleLeptonFromT : xsec*0.5
+TT : TTJets_SingleLeptonFromTbar : xsec*0.5
+TT : TTSemi_pow : xsec*0.5

--- a/TTHAnalysis/python/plotter/ttH-multilepton/mcc-ptRatiov3.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/mcc-ptRatiov3.txt
@@ -1,0 +1,1 @@
+LepGood_jetPtRatiov2 : LepGood_jetPtRatiov3; AlsoData

--- a/TTHAnalysis/python/plotter/ttH-multilepton/pack_fake_rates_data.py
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/pack_fake_rates_data.py
@@ -153,33 +153,36 @@ if __name__ == "__main__":
        an = args[1].lower()
 
        if an == 'tth':
+           mva="090"
+           if len(args)>2: mva=args[2]
            # TTH
 
-           h2d_el = [ make2D(outfile,"FR_mva090_el_"+X, ptbins_el, etabins_el) for X in XsQ ]
-           h2d_mu = [ make2D(outfile,"FR_mva090_mu_"+X, ptbins_mu, etabins_mu) for X in XsQ ]
-           h2d_el_tt = [ make2D(outfile,"FR_mva090_el_TT", ptbins_el, etabins_el) ]
-           h2d_mu_tt = [ make2D(outfile,"FR_mva090_mu_TT", ptbins_mu, etabins_mu) ]
+           h2d_el = [ make2D(outfile,"FR_mva"+mva+"_el_"+X, ptbins_el, etabins_el) for X in XsQ ]
+           h2d_mu = [ make2D(outfile,"FR_mva"+mva+"_mu_"+X, ptbins_mu, etabins_mu) for X in XsQ ]
+           h2d_el_tt = [ make2D(outfile,"FR_mva"+mva+"_el_TT", ptbins_el, etabins_el) ]
+           h2d_mu_tt = [ make2D(outfile,"FR_mva"+mva+"_mu_TT", ptbins_mu, etabins_mu) ]
 
            Plots="plots/94X/ttH/lepMVA/v2.0-dev/fr-meas"
            Z3l="z3l"
            QCD="qcd1l"
-           readMany2D(XsQ, h2d_el, "/".join([Plots, QCD, "el/HLT_EleX_OR/fakerates-mtW1R/fr_sub_eta_%s_comp.root"]), "%s", etaslices_el, (15,999) )
-           readMany2D(XsQ, h2d_mu, "/".join([Plots, QCD, "mu/HLT_MuX_OR/fakerates-mtW1R/fr_sub_eta_%s_comp.root"]), "%s", etaslices_mu, (10,999) )
+           prefix=("loose_" if mva == "075" else "")
+           readMany2D(XsQ, h2d_el, "/".join([Plots, QCD, prefix+"el/HLT_EleX_OR/fakerates-mtW1R/fr_sub_eta_%s_comp.root"]), "%s", etaslices_el, (15,999) )
+           readMany2D(XsQ, h2d_mu, "/".join([Plots, QCD, prefix+"mu/HLT_MuX_OR/fakerates-mtW1R/fr_sub_eta_%s_comp.root"]), "%s", etaslices_mu, (10,999) )
 
            if options.fixLastBin:
                fixLastBin(-1, h2d_el[1], h2d_el[0])
                fixLastBin(-1, h2d_mu[1], h2d_mu[0])
 
            #### TT MC-truth
-           MCPlots="plots/94X/ttH/lepMVA/v2.0-dev/fr-mc"; ID="wp090iv01f60E3";
-           XVar="mvaPt_090i_ptJI90_mvaPt090"
+           MCPlots="plots/94X/ttH/lepMVA/v2.0-dev/fr-mc"; ID="wp"+mva+"iv01f60E3";
+           XVar="mvaPt_"+mva+"i_ptJI90_mvaPt"+mva
            readMany2D(["TT_SS_red"], h2d_mu_tt, "/".join([MCPlots, "mu_bnb_"+ID+"_recJet30_eta_%s.root"]), XVar+"_coarsecomb_%s",   etaslices_mu, (15,999) )
            readMany2D(["TT_SS_redNC"], h2d_el_tt, "/".join([MCPlots, "el_bnbNC_"+ID+"_recJet30_eta_%s.root"]), XVar+"_coarseelcomb_%s",   etaslices_el, (15,999) )
 
-           h2d_el_mc4cc = [ make2D(outfile,"FR_mva090_el_MC"+X, ptbins_el, etabins_el) for X in ("QCD","QCDNC") ]
+           h2d_el_mc4cc = [ make2D(outfile,"FR_mva"+mva+"_el_MC"+X, ptbins_el, etabins_el) for X in ("QCD","QCDNC") ]
            readMany2D(["QCDEl_red_El8", "QCDEl_redNC_El8"],  h2d_el_mc4cc, "/".join([MCPlots, "el_hltid8_" +ID+"_recJet30_eta_%s.root"]), XVar+"_coarseelcomb_%s",   etaslices_el, (15,32) )
            readMany2D(["QCDEl_red_El17","QCDEl_redNC_El17"], h2d_el_mc4cc, "/".join([MCPlots, "el_hltid17_"+ID+"_recJet30_eta_%s.root"]), XVar+"_coarseelcomb_%s",   etaslices_el, (32,999) )
-           h2d_el_cc = [ make2D(outfile,"FR_mva090_el_"+X+"_NC", ptbins_el, etabins_el) for X in XsQ ]
+           h2d_el_cc = [ make2D(outfile,"FR_mva"+mva+"_el_"+X+"_NC", ptbins_el, etabins_el) for X in XsQ ]
            for hu,hc in zip(h2d_el,h2d_el_cc):
               for ie in xrange(1,len(etabins_el)):
                 for ip in xrange(1,len(ptbins_el)):

--- a/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l.txt
@@ -17,6 +17,7 @@ dcvsvlDen:  LepGood_mvaTTH > 0.90 ||  ( LepGood_jetBTagDeepCSV < 0.07 && (abs(Le
 num : LepGood_mediumMuonId > 0 && LepGood_mvaTTH > 0.90 ; Disable=True
 pt10 : LepGood_pt > 10; Disable=True
 conePt10 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 10; Disable=True
+mva075_conePt10 : LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 10; Disable=True
 conePt15 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15; Disable=True
 conePt20 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 20; Disable=True
 conePt30 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 30; Disable=True
@@ -24,14 +25,24 @@ conePt45 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90
 conePt65 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 65; Disable=True
 conePt81 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 81; Disable=True
 notConePt100 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 100 ; Disable=True
+mva075_notConePt100 : LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 100 ; Disable=True
 trigMu   : ( HLT_FR_Mu3_PFJet40 && LepGood_awayJet_pt > 45 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 32  ) || \
              ( HLT_FR_Mu8  && LepGood_pt >  8 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15  ) || \
              ( HLT_FR_Mu17 && LepGood_pt > 17 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32  ) || \
              ( HLT_FR_Mu20 && LepGood_pt > 20 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32 ) || \
              ( HLT_FR_Mu27 && LepGood_pt > 27 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 45 ); Disable=True
+mva075_trigMu   : ( HLT_FR_Mu3_PFJet40 && LepGood_awayJet_pt > 45 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 32  ) || \
+             ( HLT_FR_Mu8  && LepGood_pt >  8 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15  ) || \
+             ( HLT_FR_Mu17 && LepGood_pt > 17 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32  ) || \
+             ( HLT_FR_Mu20 && LepGood_pt > 20 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32 ) || \
+             ( HLT_FR_Mu27 && LepGood_pt > 27 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 45 ); Disable=True
 trigEl   : ( HLT_FR_Ele8_CaloIdM_TrackIdM_PFJet30  && LepGood_pt >  8 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 45  ) || \
            ( HLT_FR_Ele17_CaloIdM_TrackIdM_PFJet30 && LepGood_pt > 17 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 25 ) || \
            ( HLT_FR_Ele23_CaloIdM_TrackIdM_PFJet30 && LepGood_pt > 23 && LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32 ); Disable=True
+
+mva075_trigEl   : ( HLT_FR_Ele8_CaloIdM_TrackIdM_PFJet30  && LepGood_pt >  8 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 15 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) < 45  ) || \
+           ( HLT_FR_Ele17_CaloIdM_TrackIdM_PFJet30 && LepGood_pt > 17 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 25 ) || \
+           ( HLT_FR_Ele23_CaloIdM_TrackIdM_PFJet30 && LepGood_pt > 23 && LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 32 ); Disable=True
 
 metFilters : Flag_goodVertices && Flag_globalTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && Flag_BadChargedCandidateFilter $DATA{&& Flag_eeBadScFilter} && Flag_ecalBadCalibFilter; Disable=True
 

--- a/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l.txt
@@ -15,6 +15,7 @@ idEmuCut: LepGood_idEmu3
 #cvslDen:  LepGood_mvaTTH > 0.75 || (abs(LepGood_pdgId)==13 && LepGood_jetBTagCSV < 0.5426) || (abs(LepGood_pdgId)==11 && (LepGood_mvaIdSpring16GP > -0.5 || abs(LepGood_eta)<1.479))
 dcvsvlDen:  LepGood_mvaTTH > 0.90 ||  ( LepGood_jetBTagDeepCSV < 0.07 && (abs(LepGood_pdgId)==13 && LepGood_segmentCompatibility > 0.3 || abs(LepGood_pdgId)==11 && LepGood_mvaIdFall17noIso > +0.5)) 
 num : LepGood_mediumMuonId > 0 && LepGood_mvaTTH > 0.90 ; Disable=True
+wSel : mt_2(met_pt,met_phi,LepGood_pt,LepGood_phi) > 50; Disable=True
 pt10 : LepGood_pt > 10; Disable=True
 conePt10 : LepGood_pt*if3(LepGood_mvaTTH>0.90&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 10; Disable=True
 mva075_conePt10 : LepGood_pt*if3(LepGood_mvaTTH>0.75&&LepGood_mediumMuonId>0, 1.0, 0.90/LepGood_jetPtRatiov2) > 10; Disable=True

--- a/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l_plots.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/qcd1l_plots.txt
@@ -48,6 +48,9 @@ dPhi : abs(deltaPhi(LepGood_phi, LepGood_awayJet_phi)) : 30,0,3.14 ; XTitle="#De
 dEta : abs(LepGood_eta-LepGood_awayJet_eta) : 30,0,5; XTitle="#Delta#eta(lep\, away jet)"
 
 met : met_pt : 30,0,140; XTitle="E_{T}^{miss} (GeV)", Logy, YMin=0.9, MoreY=100
+met_1 : met_pt : 30,0,140; XTitle="E_{T}^{miss} (GeV)"
 nvtx : nVert: 60,-0.5,59.5; XTitle="N(vtx)"
 mtW1 : mt_2(met_pt,met_phi,LepGood_pt,LepGood_phi) : 40,0,160; XTitle="M_{T}(l\, E_{T}^{miss}) (GeV)", Logy, YMin=0.9, MoreY=100
+mtW1_1 : mt_2(met_pt,met_phi,LepGood_pt,LepGood_phi) : 40,0,160; XTitle="M_{T}(l\, E_{T}^{miss}) (GeV)" 
 mtW1R : mt_2(met_pt,met_phi,35,LepGood_phi) : 40,0,160; XTitle="M_{T}^{fix}(l\, E_{T}^{miss}) (GeV)", Logy, YMin=0.9, MoreY=100
+ptW : pt_2(met_pt,met_phi,LepGood_pt,LepGood_phi) : 40,0,160; XTitle="p_{T}(l\, E_{T}^{miss}) (GeV)", Logy, YMin=0.9, MoreY=100

--- a/TTHAnalysis/python/plotter/ttH-multilepton/systsEnv.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/systsEnv.txt
@@ -44,7 +44,7 @@ CMS_ttHl16_btag_cErr1	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : bTag_cE
 CMS_ttHl16_btag_cErr2	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : bTag_cErr2 	: templates
 
 # statistical fluctuations of all templates
-CMS_ttHl16_templstat 	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs|data_fakes|data_flips : .* : 1.0 : stat_foreach_shape_bins : .*
+CMS_ttHl16_templstat 	: .* : .* : 1.0 : stat_foreach_shape_bins : .*
 
 # Diboson background
 CMS_ttHl_EWK_stat : EWK : .*3l.* : 1.1
@@ -103,26 +103,18 @@ CMS_ttHl16_FRm_be	  : data_fakes  : .* : FRm_be 	: templatesShapeOnly
 # 3) Closure: QCD vs. TT fake rate, normalization
 CMS_ttHl16_Clos_e_norm : data_fakes : .*2lss_ee.* : 1.2
 CMS_ttHl16_Clos_e_norm : data_fakes : .*2lss_em.* : 1.1
-CMS_ttHl16_Clos_e_norm : data_fakes : .*3l_.* : 1.1
+CMS_ttHl16_Clos_e_norm : data_fakes : .*3l_.* : 1.25
 CMS_ttHl16_Clos_e_bt_norm : data_fakes : .*2lss_em_bt.* : 1.1
 CMS_ttHl16_Clos_e_bt_norm : data_fakes : .*3l_bt.* : 1.1
 CMS_ttHl16_Clos_m_norm : data_fakes : .*2lss_mm.* : 1.2
 CMS_ttHl16_Clos_m_norm : data_fakes : .*2lss_em.* : 1.1
-CMS_ttHl16_Clos_m_norm : data_fakes : .*3l_.* : 1.15
+CMS_ttHl16_Clos_m_norm : data_fakes : .*3l_.* : 1.25
 CMS_ttHl16_Clos_m_bt_norm : data_fakes : .*2lss_mm_bt.* : 1.3
 CMS_ttHl16_Clos_m_bt_norm : data_fakes : .*2lss_em_bt.* : 1.15
-CMS_ttHl16_Clos_m_bt_norm : data_fakes : .*3l_bt.* : 1.15
+CMS_ttHl16_Clos_m_bt_norm : data_fakes : .*3l_bt.* : 1.2
 
 # 4) Closure: QCD vs. TT fake rate, shape
-CMS_ttHl16_Clos_e_bl_shape : data_fakes  : .*2lss_ee.*	: 1.0 : shapeOnly2D_0.83X_1.20Y
-CMS_ttHl16_Clos_e_bl_shape : data_fakes  : .*2lss_em_bl.* : 1.0 : shapeOnly2D_0.83X_1.20Y
-CMS_ttHl16_Clos_e_bt_shape : data_fakes  : .*2lss_em_bt.* : 1.0 : shapeOnly2D_0.71X_1.10Y
-CMS_ttHl16_Clos_e_bl_shape : data_fakes  : .*3l.*      	: 1.0 : shapeOnly2D_0.83X_1.20Y
-CMS_ttHl16_Clos_m_bl_shape : data_fakes  : .*2lss_mm_bl.* : 1.0 : shapeOnly2D_1.10X_1.10Y
-CMS_ttHl16_Clos_m_bt_shape : data_fakes  : .*2lss_mm_bt.* : 1.0 : shapeOnly2D_2.00X_1.20Y
-CMS_ttHl16_Clos_m_bl_shape : data_fakes  : .*2lss_em_bl.* : 1.0 : shapeOnly2D_1.31X_1.30Y
-CMS_ttHl16_Clos_m_bt_shape : data_fakes  : .*2lss_em_bt.* : 1.0 : shapeOnly2D_1.30X_1.40Y
-CMS_ttHl16_Clos_m_bl_shape : data_fakes  : .*3l.*      	: 1.0 : shapeOnly2D_1.10X_1.10Y
+# 2017 ones not implemented in systsEnv.txt --> see systsUnc.txt
 
 # Charge flip uncertainty
 CMS_ttHl_QF     : data_flips  : .* : 1.3

--- a/TTHAnalysis/python/plotter/ttH-multilepton/systsUnc.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/systsUnc.txt
@@ -1,55 +1,68 @@
 # vim: syntax=sh
-lumi_13TeV_2016		: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : normSymm : 1.026
+
+
+### Alias definitions. Careful to avoid trailing '.*' to avoid matching _promptsub
+$alias : ttH : ttH|ttH_h[a-z]+
+$alias : tHq : tHq|tHq_h[a-z]+
+$alias : tHW : tHW|tHW_h[a-z]+
+$alias : ttHX : $ttH|$tHq|$tHW
+$alias : ttV  : TT[WZ]|TTWW
+$alias : PromptFromMC : $ttHX|$ttV|Rares|Convs  # note that EWK is excluded as it's normalized to data
+
+### Uncertainties
+
+lumi_13TeV_2016		: $PromptFromMC : .* : normSymm : 1.026
 
 # lepton efficiencies
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.02\, 1.04)'
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_ee.* : none
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_mm.* : normSymm : 1.04
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_em.* : normSymm : 1.02
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*3l.* : normSymm : 1.03
-CMS_ttHl16_lepEff_muloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*4l.* : normSymm : 1.04
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.02\, 1.04)'
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*2lss_ee.* : none
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*2lss_mm.* : normSymm : 1.04
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*2lss_em.* : normSymm : 1.02
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*3l.* : normSymm : 1.03
+CMS_ttHl16_lepEff_muloose : $PromptFromMC : .*4l.* : normSymm : 1.04
 
-CMS_ttHl16_lepEff_elloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss.* : templateAsymm ; AddWeights=['elLooseUnc_2lss_up'\,'elLooseUnc_2lss_dn']
-CMS_ttHl16_lepEff_elloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*3l*    : templateAsymm ; AddWeights=['elLooseUnc_3l_up'\,'elLooseUnc_3l_dn']
-CMS_ttHl16_lepEff_elloose : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*4l*    : templateAsymm ; AddWeights=['elLooseUnc_4l_up'\,'elLooseUnc_4l_dn']
+CMS_ttHl16_lepEff_elloose : $PromptFromMC : .*2lss.* : templateAsymm ; AddWeights=['elLooseUnc_2lss_up'\,'elLooseUnc_2lss_dn']
+CMS_ttHl16_lepEff_elloose : $PromptFromMC : .*3l*    : templateAsymm ; AddWeights=['elLooseUnc_3l_up'\,'elLooseUnc_3l_dn']
+CMS_ttHl16_lepEff_elloose : $PromptFromMC : .*4l*    : templateAsymm ; AddWeights=['elLooseUnc_4l_up'\,'elLooseUnc_4l_dn']
 
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.03\, 1.06)'
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_ee.* : none
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_mm.* : normSymm : 1.06
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_em.* : normSymm : 1.03
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*3l.* : normSymm : 1.04
-CMS_ttHl16_lepEff_mutight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*4l.* : normSymm : 1.06
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.03\, 1.06)'
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*2lss_ee.* : none
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*2lss_mm.* : normSymm : 1.06
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*2lss_em.* : normSymm : 1.03
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*3l.* : normSymm : 1.04
+CMS_ttHl16_lepEff_mutight : $PromptFromMC : .*4l.* : normSymm : 1.06
 
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.06\, 1.03\, 1.00)'
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_ee.* : normSymm : 1.06
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_em.* : normSymm : 1.03
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_mm.* : none
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*3l.* : normSymm : 1.04
-CMS_ttHl16_lepEff_eltight : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*4l.* : normSymm : 1.06
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.06\, 1.03\, 1.00)'
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*2lss_ee.* : normSymm : 1.06
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*2lss_em.* : normSymm : 1.03
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*2lss_mm.* : none
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*3l.* : normSymm : 1.04
+CMS_ttHl16_lepEff_eltight : $PromptFromMC : .*4l.* : normSymm : 1.06
+
 
 ### todo: replace with tau veto efficiency
-#CMS_ttHl_tauID		: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_1tau.* : 1.1
+#CMS_ttHl_tauID		: $PromptFromMC : .*2lss_1tau.* : 1.1
 
 # trigger efficiencies
-CMS_ttHl16_trigger_ee	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_ee.* : normSymm : 1.02
-CMS_ttHl16_trigger_em	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_em.* : normSymm : 1.01
-CMS_ttHl16_trigger_mm	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*2lss_mm.* : normSymm : 1.01
-CMS_ttHl16_trigger_3l	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*3l.* : normSymm : 1.03
-CMS_ttHl16_trigger_3l	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .*4l.* : normSymm : 1.03
+CMS_ttHl16_trigger_ee	: $PromptFromMC : .*2lss_ee.* : normSymm : 1.02
+CMS_ttHl16_trigger_em	: $PromptFromMC : .*2lss_em.* : normSymm : 1.01
+CMS_ttHl16_trigger_mm	: $PromptFromMC : .*2lss_mm.* : normSymm : 1.01
+CMS_ttHl16_trigger_3l	: $PromptFromMC : .*3l.* : normSymm : 1.03
+CMS_ttHl16_trigger_3l	: $PromptFromMC : .*4l.* : normSymm : 1.03
 
 
-CMS_scale_j	: ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; \
+CMS_scale_j	: $PromptFromMC : .* : templateAsymm; \
         FakeRates=['ttH-multilepton/fr-jecUp.txt'\,'ttH-multilepton/fr-jecDn.txt'], \
         AddWeights=['eventBTagSF_up_jes/eventBTagSF'\,'eventBTagSF_down_jes/eventBTagSF']
 
-CMS_ttHl16_btag_LF    : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_lf/eventBTagSF'\,'eventBTagSF_down_lf/eventBTagSF']		
-CMS_ttHl16_btag_HF    : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_hf/eventBTagSF'\,'eventBTagSF_down_hf/eventBTagSF']
-CMS_ttHl16_btag_LFStats1   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_lfstats1/eventBTagSF'\,'eventBTagSF_down_lfstats1/eventBTagSF']		
-CMS_ttHl16_btag_HFStats1   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_hfstats1/eventBTagSF'\,'eventBTagSF_down_hfstats1/eventBTagSF']
-CMS_ttHl16_btag_LFStats2   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_lfstats2/eventBTagSF'\,'eventBTagSF_down_lfstats2/eventBTagSF']		
-CMS_ttHl16_btag_HFStats2   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_hfstats2/eventBTagSF'\,'eventBTagSF_down_hfstats2/eventBTagSF']
-CMS_ttHl16_btag_cErr1   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_cferr1/eventBTagSF'\,'eventBTagSF_down_cferr1/eventBTagSF']
-CMS_ttHl16_btag_cErr2   : ttH.*|TT[WZ]|tHq.*|tHW.*|TTWW|Rares|Convs : .* : templateAsymm; AddWeights=['eventBTagSF_up_cferr2/eventBTagSF'\,'eventBTagSF_down_cferr2/eventBTagSF']
+CMS_ttHl16_btag_LF    : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_lf/eventBTagSF'\,'eventBTagSF_down_lf/eventBTagSF']		
+CMS_ttHl16_btag_HF    : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_hf/eventBTagSF'\,'eventBTagSF_down_hf/eventBTagSF']
+CMS_ttHl16_btag_LFStats1   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_lfstats1/eventBTagSF'\,'eventBTagSF_down_lfstats1/eventBTagSF']		
+CMS_ttHl16_btag_HFStats1   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_hfstats1/eventBTagSF'\,'eventBTagSF_down_hfstats1/eventBTagSF']
+CMS_ttHl16_btag_LFStats2   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_lfstats2/eventBTagSF'\,'eventBTagSF_down_lfstats2/eventBTagSF']		
+CMS_ttHl16_btag_HFStats2   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_hfstats2/eventBTagSF'\,'eventBTagSF_down_hfstats2/eventBTagSF']
+CMS_ttHl16_btag_cErr1   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_cferr1/eventBTagSF'\,'eventBTagSF_down_cferr1/eventBTagSF']
+CMS_ttHl16_btag_cErr2   : $PromptFromMC : .* : templateAsymm; AddWeights=['eventBTagSF_up_cferr2/eventBTagSF'\,'eventBTagSF_down_cferr2/eventBTagSF']
 
 # Diboson background
 CMS_ttHl_EWK_stat : EWK : .*3l.* : normSymm : 1.1
@@ -67,16 +80,16 @@ CMS_ttHl_Convs		: Convs : .* : normSymm : 1.3
 
 # common theoretical uncertainties (fully correlated everywhere)
 # note: pdf_gg is entered as 1/kappa since it has to be anti-correlated with Hgg
-QCDscale_ttH   : ttH.* : .* : normAsymm : 0.915 : 1.058
+QCDscale_ttH   : $ttH  : .* : normAsymm : 0.915 : 1.058
 QCDscale_ttW   : TTW   : .* : normSymm : 1.12
 QCDscale_ttZ   : TTZ   : .* : normSymm : 1.11
-QCDscale_tHq   : tHq.*   : .* : normAsymm : 0.933 : 1.041
-QCDscale_tHW   : tHW.*   : .* : normAsymm : 0.939 : 1.046
+QCDscale_tHq   : $tHq  : .* : normAsymm : 0.933 : 1.041
+QCDscale_tHW   : $tHW  : .* : normAsymm : 0.939 : 1.046
 QCDscale_ttWW  : TTWW  : .* : normAsymm : 0.891 : 1.081
-pdf_Higgs_ttH  : ttH.* : .* : normSymm : 1.036
+pdf_Higgs_ttH  : $ttH  : .* : normSymm : 1.036
 pdf_gg         : TTZ   : .* : normSymm : 0.966
-pdf_qg	       : tHq.*   : .* : normSymm : 1.01
-pdf_qg	       : tHW.*   : .* : normSymm : 1.027
+pdf_qg	       : $tHq  : .* : normSymm : 1.01
+pdf_qg	       : $tHW  : .* : normSymm : 1.027
 pdf_qqbar      : TTW   : .* : normSymm : 1.04
 pdf_TTWW       : TTWW  : .* : normSymm : 1.03
 
@@ -86,12 +99,12 @@ BR_hzz	       : ttH_hzz       : .* : normSymm : 1.0154
 BR_htt	       : ttH_htt       : .* : normSymm : 1.0165
 
 # shape theoretical uncertainties (private to this channel)
-#CMS_ttHl_thu_shape_ttH  : ttH.* : .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.05\,kinMVA_2lss_ttbar_withBDTv8\,-1\,1)*lnN1D_p1(1.02\,kinMVA_2lss_ttV_withHj\,-1\,1)' #shapeOnly2D_1.05X_1.02Y
-#CMS_ttHl_thu_shape_ttW  : TTW 	: .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.02\,kinMVA_2lss_ttbar_withBDTv8\,-1\,1)*lnN1D_p1(1.03\,kinMVA_2lss_ttV_withHj\,-1\,1)' #shapeOnly2D_1.02X_1.03Y
-#CMS_ttHl_thu_shape_ttZ  : TTZ 	: .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.06\,kinMVA_2lss_ttbar_withBDTv8\,-1\,1)*lnN1D_p1(1.06\,kinMVA_2lss_ttV_withHj\,-1\,1)' #shapeOnly2D_1.06X_1.06Y
-#CMS_ttHl_thu_shape_ttH  : ttH.* : .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.05\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.10\,kinMVA_3l_ttV_withMEM\,-1\,1)' #shapeOnly2D_1.05X_1.10Y
-#CMS_ttHl_thu_shape_ttW  : TTW 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.04\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.10\,kinMVA_3l_ttV_withMEM\,-1\,1)' #shapeOnly2D_1.04X_1.10Y
-#CMS_ttHl_thu_shape_ttZ  : TTZ 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.08\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.13\,kinMVA_3l_ttV_withMEM\,-1\,1)' #shapeOnly2D_1.08X_1.13Y
+CMS_ttHl_thu_shape_ttH  : $ttH  : .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.05\,kinMVA_2lss_ttbar\,-1\,1)*lnN1D_p1(1.02\,kinMVA_2lss_ttV\,-1\,1)' #shapeOnly2D_1.05X_1.02Y
+CMS_ttHl_thu_shape_ttW  : TTW 	: .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.02\,kinMVA_2lss_ttbar\,-1\,1)*lnN1D_p1(1.03\,kinMVA_2lss_ttV\,-1\,1)' #shapeOnly2D_1.02X_1.03Y
+CMS_ttHl_thu_shape_ttZ  : TTZ 	: .*2lss.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.06\,kinMVA_2lss_ttbar\,-1\,1)*lnN1D_p1(1.06\,kinMVA_2lss_ttV\,-1\,1)' #shapeOnly2D_1.06X_1.06Y
+CMS_ttHl_thu_shape_ttH  : $ttH  : .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.05\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.10\,kinMVA_3l_ttV\,-1\,1)' #shapeOnly2D_1.05X_1.10Y
+CMS_ttHl_thu_shape_ttW  : TTW 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.04\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.10\,kinMVA_3l_ttV\,-1\,1)' #shapeOnly2D_1.04X_1.10Y
+CMS_ttHl_thu_shape_ttZ  : TTZ 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.08\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.13\,kinMVA_3l_ttV\,-1\,1)' #shapeOnly2D_1.08X_1.13Y
 
 CMS_ttHl16_FRe_norm : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-down.txt"], \
         RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True

--- a/TTHAnalysis/python/plotter/ttH-multilepton/systsUnc.txt
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/systsUnc.txt
@@ -8,6 +8,8 @@ $alias : tHW : tHW|tHW_h[a-z]+
 $alias : ttHX : $ttH|$tHq|$tHW
 $alias : ttV  : TT[WZ]|TTWW
 $alias : PromptFromMC : $ttHX|$ttV|Rares|Convs  # note that EWK is excluded as it's normalized to data
+$alias : FRData : data_fakes|.*_promptsub
+$alias : FRAll  : data_fakes|.*_promptsub|TT_FR_QCD
 
 ### Uncertainties
 
@@ -106,29 +108,36 @@ CMS_ttHl_thu_shape_ttH  : $ttH  : .*3l.*   : templateSymm ; Normalize=True, AddW
 CMS_ttHl_thu_shape_ttW  : TTW 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.04\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.10\,kinMVA_3l_ttV\,-1\,1)' #shapeOnly2D_1.04X_1.10Y
 CMS_ttHl_thu_shape_ttZ  : TTZ 	: .*3l.*   : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.08\,kinMVA_3l_ttbar\,-1\,1)*lnN1D_p1(1.13\,kinMVA_3l_ttV\,-1\,1)' #shapeOnly2D_1.08X_1.13Y
 
-CMS_ttHl16_FRe_norm : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-down.txt"], \
+CMS_ttHl16_FRe_norm : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-down.txt"], \
         RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRe_pt : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-pt2.txt"], \
+CMS_ttHl16_FRe_norm : $FRData  : .*2lss_mm.* : none
+CMS_ttHl16_FRe_pt : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-pt2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRe_be : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-be2.txt"], \
+CMS_ttHl16_FRe_pt : $FRData  : .*2lss_mm.* : none
+CMS_ttHl16_FRe_be : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-e-be2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_norm : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-down.txt"], \
+CMS_ttHl16_FRe_be : $FRData  : .*2lss_mm.* : none
+CMS_ttHl16_FRm_norm : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-down.txt"], \
         RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_pt : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-pt2.txt"], \
+CMS_ttHl16_FRm_norm : $FRData  : .*2lss_ee.* : none
+CMS_ttHl16_FRm_pt : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-pt2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_be : data_fakes  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-be2.txt"], \
+CMS_ttHl16_FRm_pt : $FRData  : .*2lss_ee.* : none
+CMS_ttHl16_FRm_be : $FRData  : .*2lss.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-2lss-frdata-m-be2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-2lss-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRe_norm : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-down.txt"], \
+CMS_ttHl16_FRm_be : $FRData  : .*2lss_ee.* : none
+
+CMS_ttHl16_FRe_norm : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-down.txt"], \
         RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRe_pt : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-pt2.txt"], \
+CMS_ttHl16_FRe_pt : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-pt2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRe_be : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-be2.txt"], \
+CMS_ttHl16_FRe_be : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-e-be2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_norm : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-down.txt"], \
+CMS_ttHl16_FRm_norm : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-up.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-down.txt"], \
         RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_pt : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-pt2.txt"], \
+CMS_ttHl16_FRm_pt : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-pt1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-pt2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
-CMS_ttHl16_FRm_be : data_fakes  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-be2.txt"], \
+CMS_ttHl16_FRm_be : $FRData  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frdata-m-be2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-3l-frdata.txt", DoesNotChangeEventSelection=True
 
 
@@ -158,43 +167,43 @@ CMS_ttHl16_FRm_pt : TT_FR_QCD  : .*3l.* : templateAsymm; FakeRates=["ttH-multile
 CMS_ttHl16_FRm_be : TT_FR_QCD  : .*3l.* : templateAsymm; FakeRates=["ttH-multilepton/fakerate-vars/fakeRate-3l-frmc-qcd-m-be1.txt"\,"ttH-multilepton/fakerate-vars/fakeRate-3l-frmc-qcd-m-be2.txt"], \
         Normalize=True, RemoveFakeRate="ttH-multilepton/fakeRate-3l-frmc-qcd.txt"
 
-CMS_ttHl16_Clos_e_norm : data_fakes|TT_FR_QCD : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.2\, 1.1\, 1.0)'
-CMS_ttHl16_Clos_e_norm : data_fakes|TT_FR_QCD : .*2lss_ee.* : normSymm : 1.2
-CMS_ttHl16_Clos_e_norm : data_fakes|TT_FR_QCD : .*2lss_em.* : normSymm : 1.1
-CMS_ttHl16_Clos_e_norm : data_fakes|TT_FR_QCD : .*2lss_mm.* : none
-CMS_ttHl16_Clos_e_norm : data_fakes|TT_FR_QCD : .*3l.* : normSymm : 1.1
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflavnb(LepGood1_pdgId\,LepGood2_pdgId\,nBJetMedium25\, 1.0\, 1.0\,1.1\, 1.0\,1.0)'
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*2lss_ee.* : none
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*2lss_em_bl.* : none
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*2lss_em_bt.* : normSymm : 1.1
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*2lss_mm* : none
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*3l.* : templateSymm ; AddWeight='if3(nBJetMedium25<=1\, 1.0\, 1.1)'
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*3l_bl.* : none
-CMS_ttHl16_Clos_e_bt_norm : data_fakes|TT_FR_QCD : .*3l_bt.* : normSymm : 1.1
-CMS_ttHl16_Clos_m_norm : data_fakes|TT_FR_QCD : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.1\, 1.2)'
-CMS_ttHl16_Clos_m_norm : data_fakes|TT_FR_QCD : .*2lss_ee.* : none
-CMS_ttHl16_Clos_m_norm : data_fakes|TT_FR_QCD : .*2lss_em.* : normSymm : 1.1
-CMS_ttHl16_Clos_m_norm : data_fakes|TT_FR_QCD : .*2lss_mm.* : normSymm : 1.2
-CMS_ttHl16_Clos_m_norm : data_fakes|TT_FR_QCD : .*3l.* : normSymm : 1.25
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflavnb(LepGood1_pdgId\,LepGood2_pdgId\,nBJetMedium25\, 1.0\, 1.0\,1.15\, 1.0\,1.3)'
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss_ee.*    : none
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss_em_bl.* : none
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss_em_bt.* : normSymm : 1.15
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss_mm_bl.* : none
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*2lss_mm_bt.* : normSymm : 1.3
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*3l.* : templateSymm ; AddWeight='if3(nBJetMedium25<=1\, 1.0\, 1.2)'
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*3l_bl.* : none
-CMS_ttHl16_Clos_m_bt_norm : data_fakes|TT_FR_QCD : .*3l_bt.* : normSymm : 1.2
+CMS_ttHl16_Clos_e_norm : $FRAll : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.2\, 1.1\, 1.0)'
+CMS_ttHl16_Clos_e_norm : $FRAll : .*2lss_ee.* : normSymm : 1.2
+CMS_ttHl16_Clos_e_norm : $FRAll : .*2lss_em.* : normSymm : 1.1
+CMS_ttHl16_Clos_e_norm : $FRAll : .*2lss_mm.* : none
+CMS_ttHl16_Clos_e_norm : $FRAll : .*3l.* : normSymm : 1.1
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflavnb(LepGood1_pdgId\,LepGood2_pdgId\,nBJetMedium25\, 1.0\, 1.0\,1.1\, 1.0\,1.0)'
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*2lss_ee.* : none
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*2lss_em_bl.* : none
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*2lss_em_bt.* : normSymm : 1.1
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*2lss_mm* : none
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*3l.* : templateSymm ; AddWeight='if3(nBJetMedium25<=1\, 1.0\, 1.1)'
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*3l_bl.* : none
+CMS_ttHl16_Clos_e_bt_norm : $FRAll : .*3l_bt.* : normSymm : 1.1
+CMS_ttHl16_Clos_m_norm : $FRAll : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\, 1.0\, 1.1\, 1.2)'
+CMS_ttHl16_Clos_m_norm : $FRAll : .*2lss_ee.* : none
+CMS_ttHl16_Clos_m_norm : $FRAll : .*2lss_em.* : normSymm : 1.1
+CMS_ttHl16_Clos_m_norm : $FRAll : .*2lss_mm.* : normSymm : 1.2
+CMS_ttHl16_Clos_m_norm : $FRAll : .*3l.* : normSymm : 1.25
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss.* : templateSymm ; AddWeight='ttH_2lss_ifflavnb(LepGood1_pdgId\,LepGood2_pdgId\,nBJetMedium25\, 1.0\, 1.0\,1.15\, 1.0\,1.3)'
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss_ee.*    : none
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss_em_bl.* : none
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss_em_bt.* : normSymm : 1.15
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss_mm_bl.* : none
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*2lss_mm_bt.* : normSymm : 1.3
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*3l.* : templateSymm ; AddWeight='if3(nBJetMedium25<=1\, 1.0\, 1.2)'
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*3l_bl.* : none
+CMS_ttHl16_Clos_m_bt_norm : $FRAll : .*3l_bt.* : normSymm : 1.2
 
 # 4) Closure: QCD vs. TT fake rate, shape
-CMS_ttHl16_Clos_e_shape : data_fakes|TT_FR_QCD  : .*2lss.*    : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\,1.5\,1.25\,1.0)\, kinMVA_2lss_ttbar\,-1\,1)' 
-CMS_ttHl16_Clos_e_shape : data_fakes|TT_FR_QCD  : .*2lss_ee.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.5\, kinMVA_2lss_ttbar\,-1\,1)' 
-CMS_ttHl16_Clos_e_shape : data_fakes|TT_FR_QCD  : .*2lss_em.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.25\, kinMVA_2lss_ttbar\,-1\,1)' 
-CMS_ttHl16_Clos_e_shape : data_fakes|TT_FR_QCD  : .*2lss_mm.* : none
-CMS_ttHl16_Clos_m_shape : data_fakes|TT_FR_QCD  : .*2lss.*    : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\,1.0\,1.5\,1.8)\, kinMVA_2lss_ttV\,-1\,1)' 
-CMS_ttHl16_Clos_m_shape : data_fakes|TT_FR_QCD  : .*2lss_ee.* : none
-CMS_ttHl16_Clos_m_shape : data_fakes|TT_FR_QCD  : .*2lss_em.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.5\, kinMVA_2lss_ttV\,-1\,1)' 
-CMS_ttHl16_Clos_m_shape : data_fakes|TT_FR_QCD  : .*2lss_mm.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.8\, kinMVA_2lss_ttV\,-1\,1)' 
+CMS_ttHl16_Clos_e_shape : $FRAll  : .*2lss.*    : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\,1.5\,1.25\,1.0)\, kinMVA_2lss_ttbar\,-1\,1)' 
+CMS_ttHl16_Clos_e_shape : $FRAll  : .*2lss_ee.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.5\, kinMVA_2lss_ttbar\,-1\,1)' 
+CMS_ttHl16_Clos_e_shape : $FRAll  : .*2lss_em.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.25\, kinMVA_2lss_ttbar\,-1\,1)' 
+CMS_ttHl16_Clos_e_shape : $FRAll  : .*2lss_mm.* : none
+CMS_ttHl16_Clos_m_shape : $FRAll  : .*2lss.*    : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(ttH_2lss_ifflav(LepGood1_pdgId\,LepGood2_pdgId\,1.0\,1.5\,1.8)\, kinMVA_2lss_ttV\,-1\,1)' 
+CMS_ttHl16_Clos_m_shape : $FRAll  : .*2lss_ee.* : none
+CMS_ttHl16_Clos_m_shape : $FRAll  : .*2lss_em.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.5\, kinMVA_2lss_ttV\,-1\,1)' 
+CMS_ttHl16_Clos_m_shape : $FRAll  : .*2lss_mm.* : templateSymm ; Normalize=True, AddWeight='lnN1D_p1(1.8\, kinMVA_2lss_ttV\,-1\,1)' 
 
 # Charge flip uncertainty
 CMS_ttHl_QF     : data_flips  : .* : normSymm : 1.3

--- a/TTHAnalysis/python/plotter/ttH-multilepton/ttH_plots.py
+++ b/TTHAnalysis/python/plotter/ttH-multilepton/ttH_plots.py
@@ -22,8 +22,6 @@ def base(selection):
 
     CORE=' '.join([TREES,TREESONLYSKIM])
     CORE+=" -f -j 8 -l 41.4 --s2v -L ttH-multilepton/functionsTTH.cc --tree treeProducerSusyMultilepton --mcc ttH-multilepton/lepchoice-ttH-FO.txt --split-factor=-1 --WA prescaleFromSkim "# --neg"
-    if "data" in selection:
-        CORE+=' '.join(["--plotgroup data_fakes%s+='.*_promptsub%s'"%(x,x) for x in ['','_FRe_norm_Up','_FRe_norm_Dn','_FRe_pt_Up','_FRe_pt_Dn','_FRe_be_Up','_FRe_be_Dn','_FRm_norm_Up','_FRm_norm_Dn','_FRm_pt_Up','_FRm_pt_Dn','_FRm_be_Up','_FRm_be_Dn']])+" --neglist '.*_promptsub.*' "
     RATIO= " --maxRatioRange 0.0  1.99 --ratioYNDiv 505 "
     RATIO2=" --showRatio --attachRatioPanel --fixRatioRange "
     LEGEND=" --legendColumns 2 --legendWidth 0.25 "
@@ -59,6 +57,10 @@ def base(selection):
 
     return GO
 
+def promptsub(x):
+    procs = [ '' ]
+    if dowhat == "cards": procs += ['_FRe_norm_Up','_FRe_norm_Dn','_FRe_pt_Up','_FRe_pt_Dn','_FRe_be_Up','_FRe_be_Dn','_FRm_norm_Up','_FRm_norm_Dn','_FRm_pt_Up','_FRm_pt_Dn','_FRm_be_Up','_FRm_be_Dn']
+    return x + ' '.join(["--plotgroup data_fakes%s+='.*_promptsub%s'"%(x,x) for x in procs])+" --neglist '.*_promptsub.*' "
 def procs(GO,mylist):
     return GO+' '+" ".join([ '-p %s'%l for l in mylist ])
 def sigprocs(GO,mylist):
@@ -105,6 +107,7 @@ if __name__ == '__main__':
         if '_table' in torun:
             x = x.replace('mca-2lss-mc.txt','mca-2lss-mc-table.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             if '_blinddata' in torun:
                 x = x.replace('mca-2lss-mc.txt','mca-2lss-mcdata.txt')
                 x = add(x,'--xp data')
@@ -194,6 +197,7 @@ if __name__ == '__main__':
             x = x.replace('mca-3l-mc.txt','mca-3l-mc-sigextr.txt').replace('--showRatio --maxRatioRange 0 2','--showRatio --maxRatioRange 0 1 --ratioYLabel "S/B"')
         if '_data' in torun: x = x.replace('mca-3l-mc.txt','mca-3l-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             if '_blinddata' in torun:
                 x = x.replace('mca-3l-mc.txt','mca-3l-mcdata.txt')
                 x = add(x,'--xp data')
@@ -258,6 +262,7 @@ if __name__ == '__main__':
         if '_relax' in torun: x = add(x,'-X ^TTTT ')
         if '_data' in torun: x = x.replace('mca-4l-mc.txt','mca-4l-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             raise RuntimeError, 'Fakes estimation not implemented for 4l'
         runIt(x,'%s'%torun)
 
@@ -265,6 +270,7 @@ if __name__ == '__main__':
         x = base('2lss')
         if '_data' in torun: x = x.replace('mca-2lss-mc.txt','mca-2lss-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             if not '_data' in torun: raise RuntimeError
             x = x.replace('mca-2lss-mcdata.txt','mca-2lss-mcdata-frdata.txt')
         x = add(x,"-R ^4j 3j 'nJet25==3'")
@@ -312,6 +318,7 @@ if __name__ == '__main__':
         x = base('3l')
         if '_data' in torun: x = x.replace('mca-3l-mc.txt','mca-3l-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             if not '_data' in torun: raise RuntimeError
             x = x.replace('mca-3l-mcdata.txt','mca-3l-mcdata-frdata.txt')
         x = add(x,"-I 'Zveto' -X ^2b1B -E ^Bveto ")
@@ -323,6 +330,7 @@ if __name__ == '__main__':
         x = base('3l')
         if '_data' in torun: x = x.replace('mca-3l-mc.txt','mca-3l-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             if not '_data' in torun: raise RuntimeError
             x = x.replace('mca-3l-mcdata.txt','mca-3l-mcdata-frdata.txt')
         plots = ['lep2_pt','met','nJet25','mZ1']
@@ -336,6 +344,7 @@ if __name__ == '__main__':
         x = base('4l')
         if '_data' in torun: x = x.replace('mca-4l-mc.txt','mca-4l-mcdata.txt')
         if '_frdata' in torun:
+            x = promptsub(x)
             raise RuntimeError, 'Fakes estimation not implemented for 4l'
         x = add(x,"-I ^Zveto")
         runIt(x,'%s'%torun)

--- a/TTHAnalysis/python/plotter/uncertaintyFile.py
+++ b/TTHAnalysis/python/plotter/uncertaintyFile.py
@@ -148,6 +148,7 @@ class UncertaintyFile:
             self._uncertainty = []
             file = open(txtfileOrUncertainty, "r")
             if not file: raise RuntimeError, "Cannot open "+txtfileOrUncertainty+"\n"
+            aliases={}
             for line in file:
               try:
                 line = line.strip()
@@ -167,7 +168,15 @@ class UncertaintyFile:
                             (key,val) = [f.strip() for f in setting.split("=",1)]
                             extra[key] = eval(val)
                         else: extra[setting] = True
+                l0 = line
+                line = re.sub(r"\$(\w+)", (lambda m : aliases[m.group(1)] if m.group(1) in aliases else m.group(0)), line)
+                #if line != l0: print "After aliases: [%s] -> [%s]" % (l0.strip(), line.strip())
                 field = [f.strip() for f in line.split(':')]
+                if field[0] == "$alias":
+                    if field[1] in aliases: raise RuntimeError("Duplicate definition of alias $"+field[1])
+                    aliases[field[1]] = "("+field[2]+")"
+                    #print "took alias $%s for (%s)" % (field[1], field[2])
+                    continue
                 if options and getattr(options,'uncertaintiesToSelect',[]):
                     skipme = True
                     for p0 in options.uncertaintiesToSelect:

--- a/TTHAnalysis/python/tools/objFloatCalc.py
+++ b/TTHAnalysis/python/tools/objFloatCalc.py
@@ -18,10 +18,10 @@ class ObjFloatCalc:
             raise
         objs = [l for l in Collection(event,self.coll,"n"+self.coll)]
         ret = {"n"+self.coll : getattr(event,"n"+self.coll) }
-        for newvar in self.newvars.keys():
+        for newvar, func in self.newvars.iteritems():
             ret[self.coll+"_"+newvar]=[-999] * getattr(event,"n"+self.coll)
             for i,ob in enumerate(objs):
-                ret[self.coll+"_"+newvar][i] = self.newvars[newvar](ob)
+                ret[self.coll+"_"+newvar][i] = func(ob)
         return ret
 
 if __name__ == '__main__':


### PR DESCRIPTION
For the moment it's called `makeShapeCardsNew.py`

main differences:
 * instead of passing the `ttH-multilepton/systsEnv.txt` file as positional argument, you pass `--unc ttH-multilepton/systsUnc.txt`
 * there's no rebinning: you plot directly the final variable (e.g. `'OurBin2l(kinMVA_2lss_ttbar,kinMVA_2lss_ttV)'  [0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5]`) 
 * you need to specify the channel (e.g. `2lss_ee`) with `--binname` (like in mcplots) instead of `-o`
 * the mca file no longer needs all the extra processes with the systematic variations (but I've kept them for now; anyway, the new code doesn't run on things that have `SkipMe=True`). Likewise, you don't need plotgroup commands for those, it's enough to have a single `--plotgroup 'data_fakes+=.*_promptsub'`
* bin-by-bin uncertainties must be turned on from the command line (e.g. `--bbb CMS_ttHl16_templstat`), they're not part of the uncertainty file.

 minor differences:
 * the `--asimov` option needs an argument (`s+b` or `b-only`; currently in makeShapeCards.py the option makes an s+b asimov and in makeShapeCardsSusy it's b-only asimov)
 * the `--infile` and `--savefile` don't take any arguments (while in the makeShapeCards they take a dummy argument)
* nuisances that have no effect don't show up in the datacard

Aliases for processes are now supported in `systsUnc.txt` in order to avoid repeating long lists of mc-based processes.

Tested only on `mca-2lss-mcdata-frdata.txt` for the `2lss_ee` final state. `systsEnv.txt` and `systsUnc.txt` are in sync at the moment, except for shape uncertainties on ttV theory and on fake rate closure for which I didn't want to backport to the shapeOnly2D syntax.
